### PR TITLE
Create dedicated typeroot to declare imports correctly

### DIFF
--- a/src/bcoin.d.ts
+++ b/src/bcoin.d.ts
@@ -1,7 +1,0 @@
-declare module "bcoin";
-declare module "bcoin/lib/protocol/network";
-declare module "bcoin/lib/primitives/Address";
-declare module "bcoin/lib/primitives/tx";
-declare module "bcoin/lib/btc/amount";
-declare module "bcoin/lib/wallet/WalletDB";
-declare module "blgr";

--- a/src/bitcoinWallet.ts
+++ b/src/bitcoinWallet.ts
@@ -1,9 +1,4 @@
-/// <reference path="./bcoin.d.ts" />
-
-import bcoin from "bcoin";
-import Amount from "bcoin/lib/btc/amount";
-import TX from "bcoin/lib/primitives/tx";
-import WalletDB from "bcoin/lib/wallet/WalletDB";
+import { Amount, Chain, Pool, TX, WalletDB } from "bcoin";
 import Logger from "blgr";
 
 export class BitcoinWallet {
@@ -26,12 +21,12 @@ export class BitcoinWallet {
             logger: this.logger,
         });
         this.network = network;
-        this.chain = new bcoin.Chain({
+        this.chain = new Chain({
             spv: true,
             network,
             logger: this.logger,
         });
-        this.pool = new bcoin.Pool({
+        this.pool = new Pool({
             chain: this.chain,
             network,
             logger: this.logger,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-/// <reference path="./bcoin.d.ts" />
-
 /** Orchestrate the hello swap apps
  * Start 2 instances of helloSwap
  * "Link" them together. eg extract PeerId etc.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         "sourceMap": true,
         "strict": true,
         "target": "es6",
-        "allowJs": true
+        "allowJs": true,
+        "typeRoots": ["./node_modules/@types", "./types"]
     }
 }

--- a/types/bcoin/index.d.ts
+++ b/types/bcoin/index.d.ts
@@ -1,0 +1,1 @@
+declare module "bcoin";

--- a/types/blgr/index.d.ts
+++ b/types/blgr/index.d.ts
@@ -1,0 +1,1 @@
+declare module "blgr";


### PR DESCRIPTION
This PR makes two major changes:

1. We use dedicated typeroots to avoid having to manually import the declaration files
2. We change the declaration to only declare the root module to match the actual runtime structure. The `bcoin` module re-exports everything from the root, hence the old imports actually never worked? (cc @D4nte )